### PR TITLE
Include PortableGit.7z on the PortableGit branch

### DIFF
--- a/ghfw-release.sh
+++ b/ghfw-release.sh
@@ -52,7 +52,8 @@ die "Failed to build git"
 echo "Building Portable Git..."
 # This puts the Portable Git release into /tmp/WinGit
 cd / &&
-NO_COMPRESS=1 sh ./share/WinGit/portable-release.sh ghfw >/dev/null ||
+NO_SFX=1 sh ./share/WinGit/portable-release.sh ghfw >/dev/null &&
+mv "$HOME/PortableGit-ghfw.7z" /tmp/WinGit/PortableGit.7z ||
 die "Couldn't build PortableGit"
 
 echo "Committing to the PortableGit branch..."

--- a/share/WinGit/portable-release.sh
+++ b/share/WinGit/portable-release.sh
@@ -44,6 +44,6 @@ then
  echo ';!@InstallEnd@!7z' &&
  cat $TARGET7) > "$TARGET"
 else
- mv $TARGET7 > "$TARGET"
+ mv $TARGET7 "$TARGET"
 fi &&
 echo "Created $TARGET"

--- a/share/WinGit/portable-release.sh
+++ b/share/WinGit/portable-release.sh
@@ -20,6 +20,7 @@ TMPDIR=/tmp/WinGit
 
 DONT_REMOVE_BUILTINS=1 "$(dirname $0)/copy-files.sh" $TMPDIR &&
 cd "$TMPDIR" &&
+GIT_DIR=/.git git rev-parse HEAD > ./VERSION &&
 cp $MSYSGITROOT/share/WinGit/README.portable ./ &&
 cp $MSYSGITROOT/msys.bat ./git-bash.bat &&
 cp $MSYSGITROOT/git-cmd.bat ./ ||


### PR DESCRIPTION
This way consumers of this branch won't have to recompress the portable Git distribution.
