### PR TITLE
Fix a few bugs in etc/gitignore

### DIFF
--- a/etc/gitignore
+++ b/etc/gitignore
@@ -66,7 +66,7 @@ local.properties
 **/*.dotCover
 
 ## TODO: If you have NuGet Package Restore enabled, uncomment this
-#**/packages/ 
+#**/packages/
 
 # Visual C++ cache files
 ipch/
@@ -82,7 +82,7 @@ ipch/
 # ReSharper is a .NET coding add-in
 _ReSharper*
 
-# Installshield output folder 
+# Installshield output folder
 [Ee]xpress
 
 # DocProject is a documentation generator add-in
@@ -123,7 +123,7 @@ UpgradeLog*.XML
 ############
 
 # Windows image file caches
-Thumbs.db 
+Thumbs.db
 
 # Folder config file
 Desktop.ini

--- a/etc/gitignore
+++ b/etc/gitignore
@@ -1,4 +1,3 @@
-
 #################
 ## Eclipse
 #################
@@ -6,9 +5,8 @@
 *.pydevproject
 .project
 .metadata
-bin/**
-tmp/**
-tmp/**/*
+bin/
+tmp/
 *.tmp
 *.bak
 *.swp
@@ -44,8 +42,8 @@ local.properties
 *.sln.docstates
 
 # Build results
-**/[Dd]ebug/
-**/[Rr]elease/
+[Dd]ebug/
+[Rr]elease/
 *_i.c
 *_p.c
 *.ilk
@@ -63,10 +61,10 @@ local.properties
 *.tmp
 *.vspscc
 .builds
-**/*.dotCover
+*.dotCover
 
 ## TODO: If you have NuGet Package Restore enabled, uncomment this
-#**/packages/
+#packages/
 
 # Visual C++ cache files
 ipch/


### PR DESCRIPTION
There were two bugs in `etc/gitignore` that I noticed:
1. Some patterns had trailing whitespace, which basically made them not work.
2. We had a bunch of extraneous `**` in our patterns, which were causing those patterns to match fewer things than they should have.
