### PR TITLE
Fix git-svn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@ libexec/git-core
 /lib/Error.pm
 /lib/Git.pm
 /lib/Git/I18N.pm
+/lib/Git/SVN/Fetcher.pm
+/lib/Git/SVN/Prompt.pm
 /lib/perl5/5.8.8/CPAN/Config.pm*
 /share/gitweb/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "git"]
 	path = git
-	url = git://github.com/msysgit/git.git
+	url = git://github.com/aroben/git.git
 [submodule "html"]
 	path = doc/git/html
 	url = git://github.com/gitster/git-htmldocs.git

--- a/share/WinGit/copy-files.sh
+++ b/share/WinGit/copy-files.sh
@@ -66,6 +66,10 @@ tar xf - &&
 rm -rf bin/cvs.exe &&
 (test ! -f $MSYSGITROOT/lib/Git.pm || cp -u $MSYSGITROOT/lib/Git.pm lib/perl5/site_perl/Git.pm) &&
 test -f lib/perl5/site_perl/Git.pm &&
+mkdir -p lib/perl5/site_perl/Git/SVN &&
+cp $MSYSGITROOT/lib/Git/I18N.pm lib/perl5/site_perl/Git/ &&
+cp $MSYSGITROOT/lib/Git/SVN/Fetcher.pm lib/perl5/site_perl/Git/SVN/ &&
+cp $MSYSGITROOT/lib/Git/SVN/Prompt.pm lib/perl5/site_perl/Git/SVN/ &&
 gitmd5=$(md5sum bin/git.exe | cut -c 1-32) &&
 mkdir etc &&
 if test -z "$DONT_REMOVE_BUILTINS"


### PR DESCRIPTION
This pulls in msysgit/git#18 and updates the Git for Windows build to take the new Perl modules into account.
