### PR TITLE
Fetch PRs as part of git fetch

### DIFF
--- a/etc/gitconfig
+++ b/etc/gitconfig
@@ -64,11 +64,6 @@
 	cmd = \"c:/program files/Perforce/p4merge.exe\" \"$BASE\" \"$LOCAL\" \"$REMOTE\" \"$MERGED\"
 	trustExitCode = false
 
-[remote "upstream"]
-fetch = +refs/heads/*:refs/remotes/upstream/*
-fetch = +refs/pull/*/head:refs/remotes/upstream/pr/*
-
-
 [remote "origin"]
 	fetch = +refs/heads/*:refs/remotes/origin/*
 	fetch = +refs/pull/*/head:refs/remotes/origin/pr/*

--- a/etc/gitconfig
+++ b/etc/gitconfig
@@ -63,3 +63,16 @@
 [mergetool "p4"]
 	cmd = \"c:/program files/Perforce/p4merge.exe\" \"$BASE\" \"$LOCAL\" \"$REMOTE\" \"$MERGED\"
 	trustExitCode = false
+
+[remote "upstream"]
+fetch = +refs/heads/*:refs/remotes/upstream/*
+fetch = +refs/pull/*/head:refs/remotes/upstream/pr/*
+
+
+[remote "origin"]
+	fetch = +refs/heads/*:refs/remotes/origin/*
+	fetch = +refs/pull/*/head:refs/remotes/origin/pr/*
+
+[remote "upstream"]
+	fetch = +refs/heads/*:refs/remotes/upstream/*
+	fetch = +refs/pull/*/head:refs/remotes/upstream/pr/*


### PR DESCRIPTION
https://gist.github.com/piscisaureus/3342247

This makes it so that every time we fetch, we'll get the refs for all of the Pull Requests as well. On github/windows, fetching every PR for all time resulted in an extra 2MB of downloaded data, I'm not too worried about this from a perf standpoint.
