### PR TITLE
bash_profile: use auto colors to avoid ESC in redirections

### DIFF
--- a/etc/bash_profile
+++ b/etc/bash_profile
@@ -2,6 +2,6 @@
 # creates his/her own .bashrc/.bash_profile
 
 # --show-control-chars: help showing Korean or accented characters
-alias ls='ls -F --color --show-control-chars'
+alias ls='ls -F --color=auto --show-control-chars'
 alias ll='ls -l'
 


### PR DESCRIPTION
The --color option enforces esc-sequences to switch color even when the output is redirected (not a tty). This breaks things like:

```
> ls > ls.txt
```

The --color=auto alternative should be prefered.
