### PR TITLE
corrected fetchspec order so that pr references are not created/deleted

### DIFF
--- a/etc/gitconfig
+++ b/etc/gitconfig
@@ -65,5 +65,5 @@
 	trustExitCode = false
 
 [remote "origin"]
-	fetch = +refs/heads/*:refs/remotes/origin/*
 	fetch = +refs/pull/*/head:refs/remotes/origin/pr/*
+	fetch = +refs/heads/*:refs/remotes/origin/*


### PR DESCRIPTION
When doing `git fetch -p` currently, the PR branches are trashed and recreated unncessarily

```
C:\Users\brendanforster\Documents\GitHub\octokit.net [milestones-kill-your-rate-limit]> git fetch -p
From https://github.com/octokit/octokit.net
 * [new ref]         refs/pull/1/head -> origin/pr/1
 * [new ref]         refs/pull/10/head -> origin/pr/10
 * [new ref]         refs/pull/100/head -> origin/pr/100
// snip - lots of other refs being added
 * [new ref]         refs/pull/99/head -> origin/pr/99
 x [deleted]         (none)     -> origin/pr/1
 x [deleted]         (none)     -> origin/pr/10
 x [deleted]         (none)     -> origin/pr/100
// snip - lots of other refs being deleted
 x [deleted]         (none)     -> origin/pr/99
```

With this change, it now behaves as expected (tested inside a new PortableGit build):

```
remote: Counting objects: 56, done.
remote: Compressing objects: 100% (16/16), done.
remote: Total 30 (delta 25), reused 19 (delta 14)
Unpacking objects: 100% (30/30), done.
From https://github.com/octokit/octokit.net
   884d43d..0f95390  refs/pull/161/head -> origin/pr/161
 * [new ref]         refs/pull/172/head -> origin/pr/172
```
