### PR TITLE
Bypass post-checkout hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ with [GitHub for Windows](http://windows.github.com/).
 
 # How to make changes
 
+0. Make sure you have `./` in your `$PATH`, probably via `~/.bashrc`
 1. Make your changes on the `devel` branch
 2. Run `msys.bat`
 3. Inside the bash shell, run `ghfw-release.sh`

--- a/ghfw-release.sh
+++ b/ghfw-release.sh
@@ -64,12 +64,14 @@ export GIT_DIR GIT_INDEX_FILE
 rm -f $GIT_INDEX_FILE
 
 cd /tmp/WinGit &&
+mv /.git/hooks/post-checkout /.git/hooks/post-checkout.nope &&
 git add . >/dev/null &&
 for file in .gitattributes .gitignore
 do
   git checkout PortableGit $file ||
   die "Couldn't check out $file from the PortableGit branch"
-done ||
+done &&
+mv /.git/hooks/post-checkout.nope /.git/hooks/post-checkout ||
 die "Failed to add files to index"
 
 DEVEL_COMMIT=$(git rev-parse HEAD)


### PR DESCRIPTION
Upstream msysgit add some code that drops a post-checkout hook into the repo, to manage Windows locking some stuff it needs to build Git. That's great, but it doesn't work with our release script because of paths and other nonsense. And, it doesn't apply to what we do in the release script anyway. This PR modifies our release script to temporarily disable it and then enable it when we are done.

cc @shiftkey 
