### PR TITLE
Fix release script after recent git-tfs changes

### DIFF
--- a/share/WinGit/copy-files.sh
+++ b/share/WinGit/copy-files.sh
@@ -108,6 +108,6 @@ sed 's@/git/contrib/completion@/etc@g' \
 	< $MSYSGITROOT/etc/profile > etc/profile &&
 cp $MSYSGITROOT/share/resources/git.ico etc/ &&
 cp $MSYSGITROOT/share/resources/git.ico share/git-gui/lib/git-gui.ico &&
-cp $MSYSGITROOT/share/git-tfs/{*.dll,*.exe,*.config,*.xml} bin &&
+cp $MSYSGITROOT/share/git-tfs/{*.dll,*.exe,*.config} bin &&
 find bin libexec -iname \*.exe -o -iname \*.dll | sort > etc/fileList-bindimage.txt ||
 exit 1


### PR DESCRIPTION
9a7883e broke the release script, as it was still referencing `git-tfs/*/xml`. This fixes that.

**Tests**
- [x] run `ghhw-release.sh` with the changes

@spraints or @github/windows, can I get a review please?
