### PR TITLE
Always use the x86 git-tfs native binary

### DIFF
--- a/share/WinGit/copy-files.sh
+++ b/share/WinGit/copy-files.sh
@@ -109,5 +109,6 @@ sed 's@/git/contrib/completion@/etc@g' \
 cp $MSYSGITROOT/share/resources/git.ico etc/ &&
 cp $MSYSGITROOT/share/resources/git.ico share/git-gui/lib/git-gui.ico &&
 cp $MSYSGITROOT/share/git-tfs/{*.dll,*.exe,*.config} bin &&
+cp $MSYSGITROOT/share/git-tfs/NativeBinaries/x86/*.dll bin &&
 find bin libexec -iname \*.exe -o -iname \*.dll | sort > etc/fileList-bindimage.txt ||
 exit 1


### PR DESCRIPTION
Native git-tfs binaries were added with a recent git-tfs update, but the release script wasn't updated to pull them in, so git-tfs in the GitHub for Windows shell isn't working.
## To-Do
- [x] Is it okay to always use the x86 binary?
- [x] test

cc @spraints @github/windows 
