### PR TITLE
Nuke union merge

### DIFF
--- a/etc/gitattributes
+++ b/etc/gitattributes
@@ -1,11 +1,3 @@
-# Custom for Visual Studio
-*.cs     diff=csharp
-*.sln    merge=union
-*.csproj merge=union
-*.vbproj merge=union
-*.fsproj merge=union
-*.dbproj merge=union
-
 # Standard to msysgit
 *.doc	 diff=astextplain
 *.DOC	 diff=astextplain

--- a/etc/gitattributes
+++ b/etc/gitattributes
@@ -1,3 +1,6 @@
+# Custom for Visual Studio
+*.cs     diff=csharp
+
 # Standard to msysgit
 *.doc	 diff=astextplain
 *.DOC	 diff=astextplain


### PR DESCRIPTION
This reverts our custom `gitattributes` that did union merges on VS project files.

Originally, the idea was, that while this strategy is more often wrong (i.e. not what the user wanted), it also made it so that the user could fix it in Visual Studio (i.e. it didn't put conflict markers in an XML file). 

However, this part isn't often even true, because it will leave off closing tags for elements, which means that VS often can't open it anyways. RIP sanity.

/cc @github/desktop  
