### PR TITLE
Enable FS stat cache on Windows

### DIFF
--- a/etc/gitconfig
+++ b/etc/gitconfig
@@ -2,6 +2,8 @@
 	symlinks = false
 	autocrlf = true
 	editor = gitpad
+	preloadindex = true
+	fscache = true
 
 [color]
 	diff = auto


### PR DESCRIPTION
This commit enables the stat cache merged recently into msysgit, described at:

https://groups.google.com/forum/#!topic/msysgit/fL_jykUmUNE
