### PR TITLE
Adding *.publishproj to ignore

### DIFF
--- a/etc/gitignore.suggested
+++ b/etc/gitignore.suggested
@@ -127,6 +127,7 @@ publish/
 # Publish Web Output
 *.Publish.xml
 *.pubxml
+*.publishproj
 
 # NuGet Packages Directory
 ## TODO: If you have NuGet Package Restore enabled, uncomment the next line


### PR DESCRIPTION
This file is generated by Visual Studio 2013 publishing and should be ignored.
