### PR TITLE
Remove merge=union for csproj and related files in the suggested gitattributes file

### DIFF
--- a/etc/gitattributes.suggested
+++ b/etc/gitattributes.suggested
@@ -3,11 +3,6 @@
 
 # Custom for Visual Studio
 *.cs     diff=csharp
-*.sln    merge=union
-*.csproj merge=union
-*.vbproj merge=union
-*.fsproj merge=union
-*.dbproj merge=union
 
 # Standard to msysgit
 *.doc	 diff=astextplain


### PR DESCRIPTION
We made this decision a long time ago in https://github.com/github/msysgit/pull/24 but we only changed the default `.gitattributes` and not the one we use when we actually create a repository with GHfW (`.gitattributes.suggested`)
